### PR TITLE
Update README.md with new badges and replace Flask with Quart

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,15 +1,17 @@
 # CrawJUD - RPA for Judicial Processes
 
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json&style=for-the-badge)](https://github.com/astral-sh/ruff)
+[![License MIT](https://img.shields.io/badge/licence-MIT-blue.svg?style=for-the-badge)](./LICENSE)
+[![Python 3.13](https://shields.io/badge/python-3.13%20-green?style=for-the-badge&logo=python)](https://python.org/downloads/release/python-3132/)
+[![Pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?style=for-the-badge&logo=pre-commit)](https://github.com/pre-commit/pre-commit)
+
 [![Celery](https://img.shields.io/badge/celery-%23a9cc54.svg?style=for-the-badge&logo=celery&logoColor=ddf4a4)](https://docs.celeryq.dev/en/stable/)
-[![Flask](https://img.shields.io/badge/Flask-000000?style=for-the-badge&logo=flask&logoColor=white)](https://quart.palletsprojects.com/en/stable/)
+[![Quart](https://img.shields.io/badge/Quart-8A2BE2?style=for-the-badge)](https://quart.palletsprojects.com/en/stable/)
 [![Poetry](https://img.shields.io/badge/Poetry-430098?style=for-the-badge&logo=python&logoColor=white)](https://python-poetry.org/docs/)
 [![Redis](https://img.shields.io/badge/Redis-DC382D?style=for-the-badge&logo=redis&logoColor=white)](https://redis.io/)
 [![PostgreSQL](https://img.shields.io/badge/PostgreSQL-4169E1?style=for-the-badge&logo=postgresql&logoColor=white)](https://www.postgresql.org/)
 
-[![License MIT](https://img.shields.io/badge/licence-MIT-blue.svg)](./LICENSE)
-[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
-[![Python 3.13](https://shields.io/badge/python-3.13%20-green?logo=python)](https://python.org/downloads/release/python-3132/)
-[![Pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
+<!-- [![Flask](https://img.shields.io/badge/Flask-000000?style=for-the-badge&logo=flask&logoColor=white)](https://quart.palletsprojects.com/en/stable/) -->
 
 ## Description
 


### PR DESCRIPTION
Enhance the README.md by adding new badges for Ruff, License, Python version, and Pre-commit, while replacing the Flask badge with a Quart badge. The old Flask badge has been commented out.