### PR TITLE
Rem 314/bugfix trazer pdf processo

### DIFF
--- a/crawjud/bot/Utils/elements/projudi.py
+++ b/crawjud/bot/Utils/elements/projudi.py
@@ -69,9 +69,7 @@ class PROJUDI_AM(Configuracao):  # noqa: N801
     data_fim = 'input[id="dataFinalMovimentacaoFiltro"]'
     filtro = 'input[id="editButton"]'
     expand_btn_projudi = 'a[href="javascript://nop/"]'
-    table_moves = './/tr[contains(@class, "odd") or contains(@class, "even")][not(@style="display:none;")]'
-
-    agua = ""
+    table_moves = './/tr[contains(@class, "odd") or contains(@class, "even")][not(@style="display:none")]'
 
     primeira_instform1 = "#informacoesProcessuais"
     primeira_instform2 = "#tabprefix0 > #container > #includeContent > fieldset > .form"

--- a/crawjud/bot/scripts/projudi/movimentacao.py
+++ b/crawjud/bot/scripts/projudi/movimentacao.py
@@ -117,7 +117,7 @@ class Movimentacao(CrawJUD):
         """
         try:
             self.appends = []
-            self.another_append: list[tuple[any, str, str]] = []
+            self.another_append: list[tuple[dict, str, str]] = []
             self.resultados = []
 
             self.table_moves = None
@@ -144,6 +144,7 @@ class Movimentacao(CrawJUD):
 
             if len(self.another_append) > 0:
                 for data, msg, fileN in self.another_append:  # noqa: N806
+                    self.type_log = "info"
                     self.append_success([data], msg, fileN)
 
             elif len(self.appends) == 0 and len(self.another_append) == 0:
@@ -542,10 +543,10 @@ class Movimentacao(CrawJUD):
             while table_docs.get_attribute("style") == "display: none;":
                 sleep(0.25)
 
-            table_docs: WebElement = self.wait.until(ec.presence_of_element_located((By.CSS_SELECTOR, css_tr)))
-
         text_doc_1 = ""
 
+        sleep(2)
+        table_docs: WebElement = self.wait.until(ec.presence_of_element_located((By.CSS_SELECTOR, css_tr)))
         rows = table_docs.find_elements(By.TAG_NAME, "tr")
         for pos, docs in enumerate(rows):
             nomearquivo = (
@@ -591,7 +592,7 @@ class Movimentacao(CrawJUD):
 
             text_mov = self.openfile(path_pdf)
 
-            if str(self.bot_data.get("TRAZER_PDF", "NÃO")).upper() == "NÃO":
+            if str(self.bot_data.get("TRAZER_PDF", "NÃO")).upper() == "NÃO" or pos != 0:
                 sleep(1)
                 Path(path_pdf).unlink(missing_ok=True)
 

--- a/crawjud/routes/bot/__init__.py
+++ b/crawjud/routes/bot/__init__.py
@@ -55,7 +55,7 @@ async def get_model(id_: int, system: str, typebot: str, filename: str) -> Respo
 
     """
     try:
-        with app.app_context():
+        async with app.app_context():
             path_arquivo, nome_arquivo = MakeModels(filename, filename).make_output()
             response = await make_response(await send_file(f"{path_arquivo}", as_attachment=True))
             response.headers["Content-Disposition"] = f"attachment; filename={nome_arquivo}"

--- a/crawjud/utils/status/__init__.py
+++ b/crawjud/utils/status/__init__.py
@@ -174,8 +174,13 @@ class TaskExec:
                 rows = ws.max_row
 
         elif typebot == "pauta":
-            data_inicio_formated = datetime.strptime(data.get("data_inicio"), "%Y-%m-%d")
-            data_fim_formated = datetime.strptime(data.get("data_fim"), "%Y-%m-%d")
+            data_inicio_formated = data.get("data_inicio")
+            if not isinstance(data_inicio_formated, datetime.date):
+                data_inicio_formated = datetime.strptime(data_inicio_formated, "%Y-%m-%d")
+
+            data_fim_formated = data.get("data_fim")
+            if not isinstance(data_fim_formated, datetime.date):
+                data_fim_formated = datetime.strptime(data_fim_formated, "%Y-%m-%d")
 
             diff = data_fim_formated - data_inicio_formated
             rows = diff.days + 2


### PR DESCRIPTION
This pull request includes several changes across multiple files to improve type annotations, fix bugs, and enhance logging. The most important changes are grouped by theme below:

### Type Annotations and Typing Improvements:
* Updated the type of `self.another_append` to `list[tuple[dict, str, str]]` in the `queue` method to ensure correct type usage (`crawjud/bot/scripts/projudi/movimentacao.py`).
* Added type annotations for `local_defs` to ensure it is a list of tuples containing a string and a callable coroutine (`crawjud/routes/credentials/__init__.py`).

### Bug Fixes:
* Fixed a bug in the `getdocmove` method by moving the assignment of `table_docs` after a sleep to ensure the element is present (`crawjud/bot/scripts/projudi/movimentacao.py`).
* Corrected the condition in `getdocmove` to check if the position is not zero, allowing for proper handling of PDF files (`crawjud/bot/scripts/projudi/movimentacao.py`).

### Logging and Error Handling:
* Enhanced logging and error handling in the `cadastro` and `cert` methods to log exceptions and abort with a 500 status code if an error occurs (`crawjud/routes/credentials/__init__.py`).

### Code Improvements:
* Changed `with app.app_context()` to `async with app.app_context()` in the `get_model` function to properly handle asynchronous context management (`crawjud/routes/bot/__init__.py`).

These changes collectively improve the robustness, type safety, and error handling of the codebase.